### PR TITLE
Ci/travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,14 @@
 dist: trusty
 sudo: required
 language: ruby
+cache: bundler
 addons:
-  chrome: stable
+  firefox: latest
 global_env:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
 before_install:
   - gem update --system
   - gem install bundler
-  - google-chrome-stable --headless --disable-gpu --no-sandbox --disable-dev-shm-usage --remote-debugging-port=9222 http://localhost &
 script:
   - cp config/vars.yml.example config/vars.yml
   - bundle exec rake db:schema:load

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ group :development, :test do
   gem 'capybara-screenshot'
   gem 'database_cleaner'
   gem 'factory_bot_rails'
+  gem 'geckodriver-helper'
   gem 'puma'
   gem 'rspec-rails', '~> 3.5'
   gem 'selenium-webdriver'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,6 +48,8 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    archive-zip (0.12.0)
+      io-like (~> 0.3.0)
     arel (7.1.4)
     autoprefixer-rails (9.7.3)
       execjs
@@ -150,6 +152,8 @@ GEM
       rake (~> 10.1)
     font-awesome-rails (4.7.0.5)
       railties (>= 3.2, < 6.1)
+    geckodriver-helper (0.24.0)
+      archive-zip (~> 0.7)
     geo_combine (0.4.0)
       activesupport
       json-schema
@@ -183,6 +187,7 @@ GEM
     hashie (3.6.0)
     i18n (1.7.0)
       concurrent-ruby (~> 1.0)
+    io-like (0.3.0)
     jbuilder (2.9.1)
       activesupport (>= 4.2.0)
     jquery-rails (4.3.5)
@@ -389,6 +394,7 @@ DEPENDENCIES
   devise (>= 3.4.1)
   factory_bot_rails
   figs
+  geckodriver-helper
   geoblacklight (~> 1.9.0)
   jbuilder (~> 2.0)
   jquery-rails

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NYU Spatial Data Repository 🗺️
 
-![Supported Ruby Version](https://img.shields.io/badge/ruby%20version-2.5.7-green?style=flat-square) [![Maintainability](https://api.codeclimate.com/v1/badges/080a26a69fcbdb0e6286/maintainability?style=flat-square)](https://codeclimate.com/github/NYULibraries/spatial_data_repository/maintainability)  [![Dependencies](https://img.shields.io/librariesio/github/NYULibraries/spatial_data_repository?style=flat-square)](https://libraries.io/github/NYULibraries/spatial_data_repository)
+[![Build Status](https://travis-ci.org/NYULibraries/spatial_data_repository.svg?branch=master)](https://travis-ci.org/NYULibraries/spatial_data_repository) ![Supported Ruby Version](https://img.shields.io/badge/ruby%20version-2.5.7-green?style=flat-square) [![Maintainability](https://api.codeclimate.com/v1/badges/080a26a69fcbdb0e6286/maintainability?style=flat-square)](https://codeclimate.com/github/NYULibraries/spatial_data_repository/maintainability)  [![Dependencies](https://img.shields.io/librariesio/github/NYULibraries/spatial_data_repository?style=flat-square)](https://libraries.io/github/NYULibraries/spatial_data_repository)
 
 This repository tracks the implementation of GeoBlacklight used to power the front-end of NYU Libraries [Spatial Data Repository](https://geo.nyu.edu)
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -10,18 +10,15 @@ require 'selenium-webdriver'
 require 'devise'
 require 'factory_bot'
 
-Capybara.register_driver(:headless_chrome) do |app|
-  capabilities = Selenium::WebDriver::Remote::Capabilities.chrome(
-    chromeOptions: { args: %w(headless disable-gpu window-size=1280,1024) }
-  )
-
-  Capybara::Selenium::Driver.new(app,
-                                 browser: :chrome,
-                                 desired_capabilities: capabilities)
+Capybara.register_driver :firefox_headless do |app|
+  options = ::Selenium::WebDriver::Firefox::Options.new
+  options.args << '--headless'
+  Capybara::Selenium::Driver.new(app, browser: :firefox, options: options)
 end
 
-Capybara.default_driver = :headless_chrome
-Capybara.javascript_driver = :headless_chrome
+Capybara.javascript_driver = :firefox_headless
+Capybara.current_driver = Capybara.javascript_driver
+Capybara.server = :puma
 Capybara.default_max_wait_time = 15
 
 ActiveRecord::Migration.maintain_test_schema!


### PR DESCRIPTION
- Use firefox via geckodriver for headless tests (tests now run with one failure, see: https://travis-ci.org/NYULibraries/spatial_data_repository/builds/634421005#L1749)