### PR TITLE
deprecate sqllite bool_as_int on dev/test

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -36,6 +36,8 @@ Rails.application.configure do
   # Raises helpful error messages.
   config.assets.raise_runtime_errors = true
 
+  Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = true
+
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -42,4 +42,6 @@ Rails.application.configure do
 
   # Enable Web console
   config.web_console.development_only = false
+
+  Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = true
 end


### PR DESCRIPTION
Handles the following warning in dev/test db environments:

```
DEPRECATION WARNING: Leaving `ActiveRecord::ConnectionAdapters::SQLite3Adapter.represent_boolean_as_integer`
set to false is deprecated. SQLite databases have used 't' and 'f' to serialize
boolean values and must have old data converted to 1 and 0 (its native boolean
serialization) before setting this flag to true. Conversion can be accomplished
by setting up a rake task which runs
  ExampleModel.where("boolean_column = 't'").update_all(boolean_column: 1)
  ExampleModel.where("boolean_column = 'f'").update_all(boolean_column: 0)
for all models and all boolean columns, after which the flag must be set to
true by adding the following to your application.rb file:
  Rails.application.config.active_record.sqlite3.represent_boolean_as_integer = true
```