### PR TITLE
Adds metadata for diagonal and orthogonal Sunset Park lidar index maps

### DIFF
--- a/spec/fixtures/solr_documents/nyu-indexmap.json
+++ b/spec/fixtures/solr_documents/nyu-indexmap.json
@@ -20,7 +20,7 @@
   ],
   "dct_issued_s": "5/31/2016",
   "dct_provenance_s": "NYU",
-  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/38716\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/83139/nyu_2451_38716.zip\",\"https://openindexmaps.org\":\"https://raw.githubusercontent.com/OpenIndexMaps/edu.nyu/master/nyu_2451_38716.geojson\"}",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/38716\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-restricted.geo.nyu.edu/geoserver/sdr/wms\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/retrieve/83139/nyu_2451_38716.zip\",\"https://openindexmaps.org\":\"https://raw.githubusercontent.com/OpenIndexMaps/edu.nyu/master/nyu-2451-38716.geojson\"}",
   "dct_source_sm": [
 
   ],

--- a/spec/fixtures/solr_documents/sunsetpark-lidar-diagonal-fixture.json
+++ b/spec/fixtures/solr_documents/sunsetpark-lidar-diagonal-fixture.json
@@ -1,0 +1,53 @@
+{
+  "dc_creator_sm": [
+    "Debra Laefer",
+    "Anh-Vu Vo"
+  ],
+  "dc_description_s": "This collection record provides a way to consume parts of the 2019 LiDAR Dataset for Sunset Park, Brooklyn NY. It is an index of the Diagonal flight paths",
+  "dc_format_s": "GeoJSON",
+  "dc_identifier_s": "http://hdl.handle.net/2451/60459",
+  "dc_language_s": "English",
+  "dc_publisher_s": "New York University. Center for Urban Science and Progress",
+  "dc_rights_s": "Public",
+  "dc_subject_sm": [
+    "Cities and towns",
+    "Urban density",
+    "Urban development",
+    "Cities and towns--United States",
+    "Remote Sensing",
+    "Community development, Urban",
+    "Land use, urban"
+  ],
+  "dc_title_s": "Index of Diagonal Flight Paths for LiDAR Data Collection in Sunset Park, Brooklyn, NY, 2019",
+  "dc_type_s": "Dataset",
+  "dct_isPartOf_sm": [
+    "NYU Research Data",
+    "2019 Sunset Park LiDAR"
+  ],
+  "dct_issued_s": "2019",
+  "dct_provenance_s": "NYU",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/60459\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-public.geo.nyu.edu.geoserver/sdr/wms\", \"https://openindexmaps.org\":\"https://raw.githubusercontent.com/OpenIndexMaps/edu.nyu/master/nyu-2451-60459.geojson\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/122246/nyu_2451_60458_doc.zip\"}",
+  "dct_source_sm": [
+
+  ],
+  "dct_spatial_sm": [
+    "Sunset Park, Kings County, New York, United States",
+    "Brooklyn, Kings County, New York, United States",
+    "New York City, New York, United States"
+
+  ],
+  "dct_temporal_sm": [
+    "2019"
+  ],
+  "geoblacklight_version": "1.0",
+  "layer_geom_type_s": "Mixed",
+  "layer_id_s": "sdr:nyu_2451_60459",
+  "layer_modified_dt": "2019-12-19T14:28:18Z",
+  "layer_slug_s": "nyu-2451-60459",
+  "nyu_addl_dspace_s": "61433",
+  "nyu_addl_format_sm": [
+    "GeoJSON"
+  ],
+  "solr_geom": "ENVELOPE(-74.0395867889, -74.0102522224, 40.6508411236, 40.6284819074)",
+  "solr_year_i": 2019
+}

--- a/spec/fixtures/solr_documents/sunsetpark_lidar_orthog-fixture.json
+++ b/spec/fixtures/solr_documents/sunsetpark_lidar_orthog-fixture.json
@@ -1,0 +1,52 @@
+{
+  "dc_creator_sm": [
+    "Debra F. Laefer",
+    "Anh-Vu Vo"
+  ],
+  "dc_description_s": "This collection record provides a way to consume parts of the 2019 LiDAR Dataset for Sunset Park, Brooklyn NY. It is an index to the Orthogonal flight paths",
+  "dc_format_s": "GeoJSON",
+  "dc_identifier_s": "http://hdl.handle.net/2451/60460",
+  "dc_language_s": "English",
+  "dc_publisher_s": "New York University. Center for Urban Science and Progress",
+  "dc_rights_s": "Public",
+  "dc_subject_sm": [
+    "Cities and towns",
+    "Urban density",
+    "Urban development",
+    "Cities and towns--United States",
+    "Remote Sensing",
+    "Community development, Urban",
+    "Land use, Urban"
+  ],
+  "dc_title_s": "Index of Orthogonal Flight Paths for LiDAR Data Collection in Sunset Park, Brooklyn, NY, 2019",
+  "dc_type_s": "Dataset",
+  "dct_isPartOf_sm": [
+    "NYU Research Data",
+    "2019 Sunset Park LiDAR"
+  ],
+  "dct_issued_s": "2019",
+  "dct_provenance_s": "NYU",
+  "dct_references_s": "{\"http://schema.org/url\":\"http://hdl.handle.net/2451/60460\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-public.geo.nyu.edu.geoserver/sdr/wms\", \"https://openindexmaps.org\":\"https://raw.githubusercontent.com/OpenIndexMaps/edu.nyu/master/nyu-2451-60460.geojson\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/retrieve/122246/nyu_2451_60458_doc.zip\"}",
+  "dct_source_sm": [
+
+  ],
+  "dct_spatial_sm": [
+    "Sunset Park, Kings County, New York, United States",
+    "Brooklyn, Kings County, New York, United States",
+    "New York City, New York, United States"
+  ],
+  "dct_temporal_sm": [
+    "2019"
+  ],
+  "geoblacklight_version": "1.0",
+  "layer_geom_type_s": "Mixed",
+  "layer_id_s": "sdr:nyu_2451_60460",
+  "layer_modified_dt": "2019-12-19T14:28:18Z",
+  "layer_slug_s": "nyu-2451-60460",
+  "nyu_addl_dspace_s": "61434",
+  "nyu_addl_format_sm": [
+    "GeoJSON"
+  ],
+  "solr_geom": "ENVELOPE(-74.0395867889, -74.0102522224, 40.6508411236, 40.6284819074)",
+  "solr_year_i": 2019
+}


### PR DESCRIPTION
Hi Andrew, this is to add the correct JSON files for the diagonal and orthogonal flights. 