### PR TITLE
Laefer no modal fixture

### DIFF
--- a/lib/nyugeoblacklight/curated_collections.rb
+++ b/lib/nyugeoblacklight/curated_collections.rb
@@ -14,7 +14,7 @@ module NyuGeoblacklight
 
     def CuratedCollections.recent
       [
-          {title: "2019 Sunset Park LiDAR", description: "High-density LiDAR datasets of Sunset Park, Brooklyn, from Debra Laefer (NYU) and collaborators", f: {"dct_isPartOf_sm" => ["2019 Sunset Park LiDAR"]}},
+          #{title: "2019 Sunset Park LiDAR", description: "High-density LiDAR datasets of Sunset Park, Brooklyn, from Debra Laefer (NYU) and collaborators", f: {"dct_isPartOf_sm" => ["2019 Sunset Park LiDAR"]}},
           {title: "2004 New York State Tax Parcels", description: "Point data on property ownership and land value", f: {"dct_isPartOf_sm" => ["NYS GIS Clearinghouse"]}},
           {title: "2011 India Census Data", description: "Vector village-level demographic data from the 2011 India Census", f: { "dc_publisher_s" => ["ML InfoMap (Firm)"]}}
       ]
@@ -23,7 +23,7 @@ module NyuGeoblacklight
     def CuratedCollections.maps
       [
           {title: "2015 Aerial Laser and Photogrammetry Survey of Dublin", slug: "nyu-2451-38684"},
-          {title: "2019 Aerial Lasar and Photogrammetry Survey of Sunset Park, Brooklyn", slug: "nyu-2451-60458"},
+          #{title: "2019 Aerial Lasar and Photogrammetry Survey of Sunset Park, Brooklyn", slug: "nyu-2451-60458"},
           {title: "China: Ch'ang-sha Region", slug: "harvard-ams7810-s250-u54-nh49-16"},
           {title: "1967 Communist China Agriculture", slug: "nyu-2451-36739"},
           {title: "2015 New York City Real Estate Sales", slug: "nyu-2451-34678"},

--- a/spec/fixtures/solr_documents/laefer-covid-test.json
+++ b/spec/fixtures/solr_documents/laefer-covid-test.json
@@ -1,0 +1,45 @@
+{
+  "dc_creator_sm": [
+    "Debra F. Laefer",
+    "Tom Kirchner",
+    "Haoran (Frank) Jiang"
+  ],
+  "dc_description_s": "This shapefile layer represents a unique dataset of 5,065 records documenting the perishable behavior of 6,075 individuals around 19 hospitals and urgent care clinics across 4 of New York’s 5 boroughs at the height of the city’s COVID-19 outbreak in the Spring of 2020 (March 22-May 19). The records were collected opportunistically by 16 student observers over 1,500 hours across all hours of the day and days of the week. The records document the date, time, location, and gender, as well as objects touched, route taken, and destination selected (including various transportation options and specific types of retail establishments). Forty-nine percent of them also noted the usage or absence of personal protective equipment (PPE) usage. Subjects were observed from a distance for periods of up to 20 minutes or for a distance of 1.3 km or until they were no longer visible from a street location. Observations were scraped from kml/kmz records generated in-situ on personal smartphones and assembled in a csv file. Each record was joined with locational information about the facility, 7 hourly weather attributes obtained from the closest weather station, and 61 attributes related to the demographics of the zip code in which the facility is located. The cleaned data are available in a csv file with a codebook and the individual kml/kmz files. This layer is a 20 percent sample of the study cases, in which the individual kmz files are joined as a single shapefile to demonstrate the high usability of the data. Initial observations include that 75 percent of individuals touched something, 11 percent touched their phone, 55 percent left the area by a form of mechanized transportation, 13 percent returned to the medical facility, and 81 percent were wearing PPE. This project was funded by a National Science Foundation grant, RAPID: DETER: Developing Epidemiology mechanisms in Three-dimensions to Enhance Response, Award 2027293, 05/20-4/21. The project is also funded by the Data Science and Software Services (DS3) program and by the Moore and Sloane foundations through the NYU Moore Sloane Data Science Environment. The data can be cited as https://doi.org/10.17609/smpm-3c34/",
+  "dc_format_s": "Shapefile",
+  "dc_identifier_s": "http://hdl.handle.net/2451/60075",
+  "dc_language_s": "English",
+  "dc_publisher_s": "New York University. Center for Urban Science and Progress",
+  "dc_rights_s": "Public",
+  "dc_subject_sm": [
+    "Health",
+    "Health Facility",
+    "Health and hygiene",
+    "Geoscientific Information"
+  ],
+  "dc_title_s": "Egress Behavior from Select NYC COVID-19 Exposed Health Facilities March-May 2020",
+  "dc_type_s": "Dataset",
+  "dct_isPartOf_sm": [
+    "NYU Research Data"
+  ],
+  "dct_issued_s": "9/15/2020",
+  "dct_provenance_s": "NYU",
+  "dct_references_s": "{\"http: //schema.org/url\":\"http://hdl.handle.net/2451/60075\",\"http://schema.org/downloadUrl\":\"https://archive.nyu.edu/bitstream/2451/60075/4/nyu_2451_60075.zip\",\"http://www.opengis.net/def/serviceType/ogc/wfs\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wfs\",\"http://www.opengis.net/def/serviceType/ogc/wms\":\"https://maps-public.geo.nyu.edu/geoserver/sdr/wms\",\"http://lccn.loc.gov/sh85035852\":\"https://archive.nyu.edu/bitstream/2451/60075/2/nyu_2451_60075_doc.zip\"}",
+    "dct_spatial_sm": [
+      "New York, New York, United States"
+    ],
+  "dct_temporal_sm": [
+    "2020"
+  ],
+  "layer_geom_type_s": "Polygon",
+  "layer_id_s": "sdr:2451_60075",
+  "layer_modified_dt": "2020-09-17T15:21:27Z",
+  "layer_slug_s": "nyu-2451-60075",
+  "nyu_addl_dspace_s": "61041",
+  "nyu_addl_id_s": "10.17609/smpm-3c34",
+  "nyu_addl_license_s": "Attribution 4.0 International (CC BY 4.0)",
+  "nyu_addl_format_sm": [
+    "Shapefile"
+  ],
+  "solr_geom": "ENVELOPE(-74.255895, -73.700272, 40.9152819999998, 40.4959289999998)",
+  "solr_year_i": 2020
+}


### PR DESCRIPTION
- [x] adds additional laefer fixture to test modal on show pages (shouldn't show if not part of lidar or sunset park collections)
- [x] temporarily disables sunset park in curated collections on home page