### PR TITLE
Cron job to clear search

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,7 @@ gem 'sqlite3'
 gem 'turbolinks'
 gem 'twitter-typeahead-rails'
 gem 'uglifier'
+gem 'whenever'
 
 # Range limit gem for slider on Solr integer fields (year)
 # Currently broken (9/2/2016)
@@ -43,5 +44,7 @@ group :development, :test do
   gem 'selenium-webdriver'
   gem 'simplecov'
   gem 'spring'
+  gem 'timecop'
   gem 'web-console'
+  gem 'whenever-test'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
       capybara (>= 1.0, < 4)
       launchy
     childprocess (4.1.0)
+    chronic (0.10.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.7)
     config (2.2.1)
@@ -381,6 +382,7 @@ GEM
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
+    timecop (0.9.6)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -403,6 +405,10 @@ GEM
     websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
+    whenever-test (1.0.1)
+      whenever
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -442,10 +448,13 @@ DEPENDENCIES
   solr_wrapper
   spring
   sqlite3
+  timecop
   turbolinks
   twitter-typeahead-rails
   uglifier
   web-console
+  whenever
+  whenever-test
 
 BUNDLED WITH
    2.1.4

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,24 @@
+# Use this file to easily define all of your cron jobs.
+#
+# It's helpful, but not entirely necessary to understand cron before proceeding.
+# http://en.wikipedia.org/wiki/Cron
+
+# Example:
+#
+# set :output, "/path/to/my/cron_log.log"
+#
+# every 2.hours do
+#   command "/usr/bin/some_great_command"
+#   runner "MyModel.some_method"
+#   rake "some:great:rake:task"
+# end
+#
+# every 4.days do
+#   runner "AnotherModel.prune_old_records"
+# end
+
+# Learn more: http://github.com/javan/whenever
+
+every 1.week do
+  rake 'vacate_searches:vacate'
+end

--- a/lib/tasks/vacate_searches.rake
+++ b/lib/tasks/vacate_searches.rake
@@ -1,5 +1,5 @@
 namespace :vacate_searches do
-  desc "Vacate week-old searches"
+  desc 'Vacate week-old searches'
   task vacate: :environment do
     Search.where('created_at < ?', (Date.today - 7.days)).destroy_all
   end

--- a/lib/tasks/vacate_searches.rake
+++ b/lib/tasks/vacate_searches.rake
@@ -1,0 +1,6 @@
+namespace :vacate_searches do
+  desc "Vacate week-old searches"
+  task vacate: :environment do
+    Search.where('created_at < ?', (Date.today - 7.days)).destroy_all
+  end
+end

--- a/spec/factories/search.rb
+++ b/spec/factories/search.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+FactoryBot.define do
+  factory :search do
+    query_params { { q: 'test' } }
+  end
+end

--- a/spec/support/tasks.rb
+++ b/spec/support/tasks.rb
@@ -1,0 +1,9 @@
+require "rake"
+
+RSpec.configure do |config|
+
+  config.before(:suite) do
+    Rails.application.load_tasks
+  end
+
+end

--- a/spec/support/tasks.rb
+++ b/spec/support/tasks.rb
@@ -1,9 +1,7 @@
-require "rake"
+require 'rake'
 
 RSpec.configure do |config|
-
   config.before(:suite) do
     Rails.application.load_tasks
   end
-
 end

--- a/spec/tasks/vacate_searches_spec.rb
+++ b/spec/tasks/vacate_searches_spec.rb
@@ -1,9 +1,7 @@
 require 'timecop'
 
-RSpec.describe "Vacate Searches", :type => :task do
-
-  context "vacate_searches:vacate" do
-
+RSpec.describe 'Vacate Searches', type: :task do
+  context 'vacate_searches:vacate' do
     before do
       # Freeze time as task is time-sensitive
       Timecop.freeze Time.now
@@ -11,27 +9,24 @@ RSpec.describe "Vacate Searches", :type => :task do
 
     after { Timecop.return }
 
-    it "deletes searches older than 1 week" do
+    it 'deletes searches older than 1 week' do
       create(:search, created_at: 2.week.ago)
       expect { invoke_task }.to change { Search.count }.by(-1)
     end
 
-    it "does not delete newer searches" do
+    it 'does not delete newer searches' do
       create(:search, created_at: 2.days.ago)
-      expect { invoke_task }.not_to change { Search.count }
+      expect { invoke_task }.not_to(change { Search.count })
     end
 
     private
 
     def invoke_task
-      task = Rake::Task["vacate_searches:vacate"]
+      task = Rake::Task['vacate_searches:vacate']
       # Ensure task is re-enabled, as rake tasks by default are disabled
       # after running once within a process http://pivotallabs.com/how-i-test-rake-tasks/
       task.reenable
       task.invoke
     end
-
   end
-
-
 end

--- a/spec/tasks/vacate_searches_spec.rb
+++ b/spec/tasks/vacate_searches_spec.rb
@@ -1,0 +1,37 @@
+require 'timecop'
+
+RSpec.describe "Vacate Searches", :type => :task do
+
+  context "vacate_searches:vacate" do
+
+    before do
+      # Freeze time as task is time-sensitive
+      Timecop.freeze Time.now
+    end
+
+    after { Timecop.return }
+
+    it "deletes searches older than 1 week" do
+      create(:search, created_at: 2.week.ago)
+      expect { invoke_task }.to change { Search.count }.by(-1)
+    end
+
+    it "does not delete newer searches" do
+      create(:search, created_at: 2.days.ago)
+      expect { invoke_task }.not_to change { Search.count }
+    end
+
+    private
+
+    def invoke_task
+      task = Rake::Task["vacate_searches:vacate"]
+      # Ensure task is re-enabled, as rake tasks by default are disabled
+      # after running once within a process http://pivotallabs.com/how-i-test-rake-tasks/
+      task.reenable
+      task.invoke
+    end
+
+  end
+
+
+end

--- a/spec/whenever/schedule_spec.rb
+++ b/spec/whenever/schedule_spec.rb
@@ -1,0 +1,14 @@
+# spec/whenever_spec.rb
+require 'spec_helper'
+
+describe 'Whenever Schedule' do
+  before do
+    load 'Rakefile' # Makes sure rake tasks are loaded so you can assert in rake jobs
+  end
+
+  it 'should have a rake task that runs every week' do
+    schedule = Whenever::Test::Schedule.new(file: 'config/schedule.rb')
+    task_name = schedule.jobs[:rake].first[:task]
+    task_name.should include('vacate_searches:vacate')
+  end
+end


### PR DESCRIPTION
## Problem
We persist `search` objects and need a manner by which to vacate old search data

## Solution
- write a rake task to vacate searches that are a week old
- use `whenever` to create a scheduled cron job

## PR Type
- [ ] Feature
- [ ] Tests
- [ ] Janitorial (refactoring, dependency updates, etc.)
