### PR TITLE
Add Logout Redirect

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,11 +27,8 @@ class ApplicationController < ActionController::Base
   # After signing out from the local application,
   # redirect to the logout path for the Login app
   def after_sign_out_path_for(resource_or_scope)
-    if logout_path.present?
-      logout_path
-    else
-      super(resource_or_scope)
-    end
+    Faraday.get(logout_path) if logout_path.present?
+    super(resource_or_scope)
   end
 
   def logout_path

--- a/spec/routing/user_routing_spec.rb
+++ b/spec/routing/user_routing_spec.rb
@@ -36,7 +36,7 @@ describe 'routes for users' do
   describe 'Logging out' do
     describe 'GET /logout' do
       subject { get('/logout') }
-      it { should route_to({ controller: 'sessions', action: 'destroy' }) }
+      it { should route_to({ controller: 'devise/sessions', action: 'destroy' }) }
     end
   end
 end

--- a/spec/routing/user_routing_spec.rb
+++ b/spec/routing/user_routing_spec.rb
@@ -1,33 +1,42 @@
 # frozen_string_literal: true
 
 describe 'routes for users' do
-  describe 'GET /auth/shibboleth' do
-    subject { get('/auth/shibboleth') }
-    it do
-      should route_to({
-                        controller: 'omniauth_callbacks',
-                        action: 'passthru'
-                      })
+  describe 'Logging in' do
+    describe 'GET /auth/shibboleth' do
+      subject { get('/auth/shibboleth') }
+      it do
+        should route_to({
+                          controller: 'omniauth_callbacks',
+                          action: 'passthru'
+                        })
+      end
+    end
+
+    describe 'POST /auth/shibboleth' do
+      subject { post('/auth/shibboleth') }
+      it do
+        should route_to({
+                          controller: 'omniauth_callbacks',
+                          action: 'passthru'
+                        })
+      end
+    end
+
+    describe 'GET /auth/shibboleth/callback' do
+      subject { get('/auth/shibboleth/callback') }
+      it { should route_to({ controller: 'omniauth_callbacks', action: 'shibboleth' }) }
+    end
+
+    describe 'POST /auth/shibboleth/callback' do
+      subject { post('/auth/shibboleth/callback') }
+      it { should route_to({ controller: 'omniauth_callbacks', action: 'shibboleth' }) }
     end
   end
 
-  describe 'POST /auth/shibboleth' do
-    subject { post('/auth/shibboleth') }
-    it do
-      should route_to({
-                        controller: 'omniauth_callbacks',
-                        action: 'passthru'
-                      })
+  describe 'Logging out' do
+    describe 'GET /logout' do
+      subject { get('/logout') }
+      it { should route_to({ controller: 'sessions', action: 'destroy' }) }
     end
-  end
-
-  describe 'GET /auth/shibboleth/callback' do
-    subject { get('/auth/shibboleth/callback') }
-    it { should route_to({ controller: 'omniauth_callbacks', action: 'shibboleth' }) }
-  end
-
-  describe 'POST /auth/shibboleth/callback' do
-    subject { post('/auth/shibboleth/callback') }
-    it { should route_to({ controller: 'omniauth_callbacks', action: 'shibboleth' }) }
   end
 end


### PR DESCRIPTION
## Problem
When users log out, they get redirected to an OAuth landing page, which is jarring.

## Solution
Add a redirect to the `root_path` to keep eyeballs on the app

## QA Environment
https://geo-stage.library.nyu.edu/

## PR Type
- [ ] Feature
- [ ] Tests
- [ ] Janitorial (refactoring, dependency updates, etc.)
