### PR TITLE
add g4a tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,6 +9,20 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_tag '$.fx.off = true;' if Rails.env.test? %>
     <%= javascript_importmap_tags %>
+    <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-JWGGYRXL2K"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){ dataLayer.push(arguments); }
+    gtag('js', new Date());
+    
+    const config = {};
+    <% if Settings.analytics_debug %>
+      config.debug_mode = true
+    <% end %>
+        
+    gtag('config', 'G-JWGGYRXL2K', config)
+  </script>
 </head>
 
   <body>

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -275,3 +275,6 @@ HELP_TEXT:
 SIDEBAR_STATIC_MAP:
   - 'iiif'
   - 'iiif_manifest'
+
+# GOOGLE ANALYTICS HANDLING
+analytics_debug: true


### PR DESCRIPTION
## Problem
Missing data stream in google analytics v4

## Solution
Add gtag script (Closes #273)

## PR Type
Feature


(Might've been easier than I thought since we don't have custom/legacy event tracking...?)

