### PR TITLE
remove "Recently Updated" and make "Featured Collection" full row

### DIFF
--- a/app/components/curated_collections/curated_collection_component.html.erb
+++ b/app/components/curated_collections/curated_collection_component.html.erb
@@ -1,4 +1,4 @@
-<div class="col-md-6">
+<div class="col-md-3">
   <div class="card-collection">
     <%= link_to search_catalog_path(f: @collection[:f] ) do %>
     <div class="card-block">

--- a/app/components/curated_collections/curated_collections_component.html.erb
+++ b/app/components/curated_collections/curated_collections_component.html.erb
@@ -1,4 +1,4 @@
-<div class="curated-collections col-6">
+<div class="curated-collections">
   <h3><%= @header %></h3>
   <div class="row">
     <% @collections.each do |collection| %>

--- a/app/views/layouts/blacklight.html.erb
+++ b/app/views/layouts/blacklight.html.erb
@@ -12,10 +12,8 @@
       <%= yield %>
       <div class="curated">
         <div class="row">
-          <%= render CuratedCollections::CuratedCollectionsComponent.new(collections: ::NyuGeoblacklight::CuratedCollections.collections.sample(2),
+          <%= render CuratedCollections::CuratedCollectionsComponent.new(collections: ::NyuGeoblacklight::CuratedCollections.collections.sample(4),
                                                                          header: 'Featured Collections') %>
-          <%= render CuratedCollections::CuratedCollectionsComponent.new(collections: ::NyuGeoblacklight::CuratedCollections.recent[0..1],
-                                                                         header: 'Recently Updated') %>
         </div>
         <%= render CuratedMaps::CuratedMapsComponent.new(maps: ::NyuGeoblacklight::CuratedCollections.maps.sample(3)) %>
       </div>


### PR DESCRIPTION
## Problem
The `Recently Updated` Feature includes data from collections we do not want to display

## Solution
Remove `Recenly Updated` widget

## PR Type
- [x] Feature
- [ ] Tests
- [ ] Janitorial (refactoring, dependency updates, etc.)

## UI Sample
![image](https://github.com/NYULibraries/spatial_data_repository/assets/12383156/37a065b0-884f-46d2-87e6-fbfb7a7d602d)
