### PR TITLE
Filter out KMZ download by type

### DIFF
--- a/app/views/catalog/_downloads_collapse.html.erb
+++ b/app/views/catalog/_downloads_collapse.html.erb
@@ -27,6 +27,7 @@
 
 <% if document.download_types.present? %>
   <% document.download_types.each do |type| %>
+    <% next if type.first == :kmz %>
     <%= download_link_generated(type.first, document) %>
   <% end %>
 <% end %>


### PR DESCRIPTION
## Problem
KMZ-type downloads are not working properly

## Solution
Remove `kmz` type from `downloads_collapse` component.

## PR Type
- [x] Feature
- [ ] Tests
- [ ] Janitorial (refactoring, dependency updates, etc.)

## UI Example

![image](https://github.com/NYULibraries/spatial_data_repository/assets/12383156/49d37d64-70c0-4f19-8d77-4b9b22abf43c)
