### PR TITLE
Upgrade mysql2 gem to 0.5.6 for libmysqlclient 8.3 support

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -326,7 +326,7 @@ GEM
     minitest (5.20.0)
     msgpack (1.7.2)
     multi_xml (0.6.0)
-    mysql2 (0.5.5)
+    mysql2 (0.5.6)
     net-http-persistent (4.0.2)
       connection_pool (~> 2.2)
     net-imap (0.3.7)
@@ -563,6 +563,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  arm64-darwin-23
   x86_64-linux
 
 DEPENDENCIES


### PR DESCRIPTION
## Problem

Running `bundle` on an Apple M2 laptop results in the following failure:

```
compiling client.c
In file included from client.c:15:
./mysql_enc_name_to_ruby.h:43:1: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in
C2x [-Wdeprecated-non-prototype]
mysql2_mysql_enc_name_to_rb_hash (str, len)
^
./mysql_enc_name_to_ruby.h:86:1: warning: a function definition without a prototype is deprecated in all versions of C and is not supported in
C2x [-Wdeprecated-non-prototype]
mysql2_mysql_enc_name_to_rb (str, len)
^
client.c:1438:3: error: call to undeclared function 'mysql_ssl_set'; ISO C99 and later do not support implicit function declarations
[-Wimplicit-function-declaration]
  mysql_ssl_set(wrapper->client,
  ^
client.c:1438:3: note: did you mean 'mysql_close'?
/opt/homebrew/Cellar/mysql/8.3.0_1/include/mysql/mysql.h:797:14: note: 'mysql_close' declared here
void STDCALL mysql_close(MYSQL *sock);
             ^
2 warnings and 1 error generated.
make: *** [client.o] Error 1

make failed, exit code 2
```

## Solution

Upgrade from mysql2 0.5.5 to 0.5.6 which addresses this issue: https://github.com/brianmario/mysql2/releases/tag/0.5.6

## Type

Dependencies