### PR TITLE
Updates rexml to address DoS vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -416,7 +416,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     retriable (3.1.2)
-    rexml (3.3.1)
+    rexml (3.3.2)
       strscan
     rgeo (3.0.0)
     rgeo-geojson (2.1.1)


### PR DESCRIPTION
## Problem

The most recent PR merge of #323 failed due to a fairly fresh DoS vulnerability in the rexml gem.

## Solution

Update rexml from 3.3.1 to 3.3.2

## Type

Dependencies