### PR TITLE
Switch from SMTP to sendmail for delivering mail

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -68,6 +68,8 @@ Rails.application.configure do
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.delivery_method = :sendmail
+
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true


### PR DESCRIPTION
## Problem

#310 - Sending records via email (and SMS) fails on Staging and Production due to an SSL issue when trying to connect via SMTP.

## Solution

Switch ActionMailer from using SMTP (the default) to using sendmail.

## Type

bug-fix