### PR TITLE
Setting a default from address for emails

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,7 +69,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.delivery_method = :sendmail
-  config.action_mailer.default_options = {from: 'no-reply@geo.nyu.edu'}
+  config.action_mailer.default_options = {from: 'lib-no-reply@nyu.edu'}
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -69,6 +69,7 @@ Rails.application.configure do
   # config.action_mailer.raise_delivery_errors = false
 
   config.action_mailer.delivery_method = :sendmail
+  config.action_mailer.default_options = {from: 'no-reply@geo.nyu.edu'}
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
## Problem

While testing out the sendmail switch, sending email now generated the following error:

```
ArgumentError (SMTP From address may not be blank: nil)
```

## Solution

Set a default from email address for ActionMailer: `no-reply@geo.nyu.edu`

## Type

bug-fix
