### PR TITLE
Disable email tool for Records

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -305,7 +305,7 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     config.add_results_collection_tool(:per_page_widget)
     config.add_show_tools_partial(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
     config.add_show_tools_partial(:citation)
-    config.add_show_tools_partial(:email, callback: :email_action, validator: :validate_email_params)
+    # config.add_show_tools_partial(:email, callback: :email_action, validator: :validate_email_params)
     config.add_show_tools_partial(:sms, if: :render_sms_action?, callback: :sms_action, validator: :validate_sms_params)
 
     # Custom tools for GeoBlacklight


### PR DESCRIPTION
Addresses #310 

## Problem

The historical usage of the Email feature does not warrant the effort required to set up an email service currently.

## Solution

Disable the email tool

## Type

Feature