### PR TITLE
Disable SMS tool for Records

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -306,7 +306,7 @@ class CatalogController < ApplicationController # rubocop:disable Metrics/ClassL
     config.add_show_tools_partial(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
     config.add_show_tools_partial(:citation)
     config.add_show_tools_partial(:email, callback: :email_action, validator: :validate_email_params)
-    config.add_show_tools_partial(:sms, if: :render_sms_action?, callback: :sms_action, validator: :validate_sms_params)
+    # config.add_show_tools_partial(:sms, if: :render_sms_action?, callback: :sms_action, validator: :validate_sms_params)
 
     # Custom tools for GeoBlacklight
     config.add_show_tools_partial :metadata, if: proc { |_context, _config, options| options[:document] && Settings.METADATA_SHOWN.intersect?(options[:document].references.refs.map(&:type).map(&:to_s)) } # rubocop:disable Performance/MapMethodChain:


### PR DESCRIPTION
Addresses #311 

## Problem

The historical usage of the SMS feature does not warrant the effort required to set up an email service currently.

## Solution

Disable the SMS tool

## Type

Feature
