### PR TITLE
Add GeoBlacklight suggested robots.txt entries

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,45 @@
-# See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+User-agent: *
+Disallow: /?q=
+Disallow: /*?q=*
+Disallow: /?f
+Disallow: /*?f*
+Disallow: /?_
+Disallow: /?bbox
+Disallow: /?page=
+Disallow: /bookmarks
+Disallow: /catalog.html?f
+Disallow: /catalog.html?_
+Disallow: /catalog.atom
+Disallow: /catalog.rss
+Disallow: /catalog/*/relations
+Disallow: /catalog/facet/*
+Disallow: /catalog/*/web_services
+Disallow: /catalog/email
+Disallow: /catalog/opensearch
+Disallow: /catalog/range_limit
+Disallow: /catalog/sms
+Disallow: /saved_searches
+Disallow: /search_history
+Disallow: /suggest
+Disallow: /users
+Disallow: /404
+Disallow: /422
+Disallow: /500
+
+User-agent: AhrefsBot
+Disallow: /
+
+User-agent: SemrushBot
+Disallow: /
+
+User-agent: PetalBot
+Disallow: /
+
+User-agent: BLEXBot
+Disallow: /
+
+User-agent: DotBot
+Disallow: /
+
+User-agent: DataForSeoBot
+Disallow: /


### PR DESCRIPTION
## Problem

We have a lot of traffic that is likely caused by crawlers and bots scraping the site.

## Solution

Use `robots.txt` entries as [suggested by the GeoBlacklight documentation](https://geoblacklight.org/docs/implementation_recommendations/) to cull some of these requests.

## Type

Enhancement