### PR TITLE
Block unsavory crawlers/bots that are generating a lot of traffic

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,4 +1,9 @@
 class Rack::Attack
+  # Crawlers, Bots & Troublemakers
+  blocklist_ip("47.76.209.138") # Alibaba Cloud HK
+  blocklist_ip("47.76.99.127")  # Alibaba Cloud HK
+  blocklist_ip("34.211.15.100") # Overly Curious EC2 Instance
+
   # Throttle all requests by IP (60rpm)
   #
   # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"


### PR DESCRIPTION
## Problem

There are a handful of nefarious crawlers/bots that are generating a lot of requests to SRD.

## Solution

Block them by IP using rack-attack

## Type

chore
