### PR TITLE
GeoBlacklight 4.4.0 Upgrade - Attempt 1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,7 @@ gem 'capistrano-rbenv', '~> 2.2'
 gem 'config'
 gem 'dalli'
 gem 'devise'
-gem 'geoblacklight', '~> 4.0'
+gem 'geoblacklight', '~> 4.4.0'
 gem 'importmap-rails'
 gem 'jbuilder'
 gem 'jquery-rails'
@@ -36,6 +36,7 @@ gem 'turbo-rails'
 gem 'twitter-typeahead-rails', '0.11.1.pre.corejavascript'
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 gem 'view_component', '~> 2.83.0'
+gem 'vite_rails', '~> 3.0'
 gem 'whenever', require: false
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,6 +179,7 @@ GEM
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     dotenv (2.8.1)
+    dry-cli (1.1.0)
     dry-configurable (1.1.0)
       dry-core (~> 1.0, < 2)
       zeitwerk (~> 2.6)
@@ -227,34 +228,41 @@ GEM
     faraday-net_http_persistent (2.1.0)
       faraday (~> 2.5)
       net-http-persistent (~> 4.0)
+    faraday-retry (2.2.1)
+      faraday (~> 2.0)
     ffi (1.15.5)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
     geckodriver-helper (0.24.0)
       archive-zip (~> 0.7)
-    geo_combine (0.8.0)
+    geo_combine (0.9.1)
       activesupport
       faraday-net_http_persistent (~> 2.0)
+      faraday-retry (~> 2.2)
       git
       json-schema
       nokogiri
       rsolr
       sanitize
       thor
-    geoblacklight (4.1.0)
-      blacklight (~> 7.33)
+    geoblacklight (4.4.0)
+      blacklight (~> 7.0)
       coderay
       config
       deprecation
-      faraday (>= 1.0)
-      geo_combine (~> 0.8)
+      faraday (~> 2.0)
+      geo_combine (~> 0.9)
       handlebars_assets
       mime-types
-      rails (>= 6.1, < 7.1)
+      rails (>= 6.1, < 7.2)
       rgeo-geojson
-    git (1.18.0)
+      sprockets-rails (~> 3.0)
+      vite_rails (~> 3.0)
+    git (2.1.1)
+      activesupport (>= 5.0)
       addressable (~> 2.8)
+      process_executer (~> 1.1)
       rchardet (~> 1.8)
     globalid (1.2.1)
       activesupport (>= 6.1)
@@ -287,7 +295,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (2.6.3)
-    json-schema (4.0.0)
+    json-schema (4.3.1)
       addressable (>= 2.8)
     jwt (2.7.1)
     kaminari (1.2.2)
@@ -319,13 +327,14 @@ GEM
     marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.1.0)
-    mime-types (3.5.1)
+    mime-types (3.5.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2023.0808)
+    mime-types-data (3.2024.0702)
     mini_mime (1.1.5)
     minitar (0.9)
     minitest (5.24.1)
     msgpack (1.7.2)
+    multi_json (1.15.0)
     multi_xml (0.6.0)
     mysql2 (0.5.6)
     net-http-persistent (4.0.2)
@@ -371,6 +380,7 @@ GEM
       ast (~> 2.4.1)
       racc
     popper_js (1.16.1)
+    process_executer (1.1.0)
     psych (5.1.2)
       stringio
     public_suffix (5.0.3)
@@ -380,6 +390,8 @@ GEM
     rack (2.2.9)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
+    rack-proxy (0.7.7)
+      rack
     rack-test (2.1.0)
       rack (>= 1.3)
     rails (7.0.8.4)
@@ -422,8 +434,9 @@ GEM
     retriable (3.1.2)
     rexml (3.3.2)
       strscan
-    rgeo (3.0.0)
-    rgeo-geojson (2.1.1)
+    rgeo (3.0.1)
+    rgeo-geojson (2.2.0)
+      multi_json (~> 1.15)
       rgeo (>= 1.0.0)
     rsolr (2.5.0)
       builder (>= 2.1.2)
@@ -477,7 +490,7 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
-    sanitize (6.0.2)
+    sanitize (6.1.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     sassc (2.4.0)
@@ -553,6 +566,13 @@ GEM
       axiom-types (~> 0.1)
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
+    vite_rails (3.0.17)
+      railties (>= 5.1, < 8)
+      vite_ruby (~> 3.0, >= 3.2.2)
+    vite_ruby (3.7.0)
+      dry-cli (>= 0.7, < 2)
+      rack-proxy (~> 0.6, >= 0.6.1)
+      zeitwerk (~> 2.2)
     warden (1.2.9)
       rack (>= 2.0.9)
     websocket (1.2.9)
@@ -591,7 +611,7 @@ DEPENDENCIES
   devise
   factory_bot_rails
   geckodriver-helper
-  geoblacklight (~> 4.0)
+  geoblacklight (~> 4.4.0)
   importmap-rails
   jbuilder
   jquery-rails
@@ -625,6 +645,7 @@ DEPENDENCIES
   twitter-typeahead-rails (= 0.11.1.pre.corejavascript)
   tzinfo-data
   view_component (~> 2.83.0)
+  vite_rails (~> 3.0)
   whenever
   whenever-test
 

--- a/app/helpers/geoblacklight_helper.rb
+++ b/app/helpers/geoblacklight_helper.rb
@@ -241,4 +241,47 @@ module GeoblacklightHelper # rubocop:disable Metrics/ModuleLength
       'index'
     end
   end
+
+  def viewer_container
+    if openlayers_container?
+      ol_viewer
+    else
+      leaflet_viewer
+    end
+  end
+
+  def openlayers_container?
+    return false unless @document
+    @document.item_viewer.pmtiles || @document.item_viewer.cog
+  end
+
+  def leaflet_viewer
+    tag.div(nil,
+            id: "map",
+            data: {
+              :map => "item", :protocol => @document.viewer_protocol.camelize,
+              :url => @document.viewer_endpoint,
+              "layer-id" => @document.wxs_identifier,
+              "map-geom" => @document.geometry.geojson,
+              "catalog-path" => search_catalog_path,
+              :available => document_available?,
+              :basemap => geoblacklight_basemap,
+              :leaflet_options => leaflet_options
+            })
+  end
+
+  def ol_viewer
+    tag.div(nil,
+            id: "ol-map",
+            data: {
+              :map => "item", :protocol => @document.viewer_protocol.camelize,
+              :url => @document.viewer_endpoint,
+              "layer-id" => @document.wxs_identifier,
+              "map-geom" => @document.geometry.geojson,
+              "catalog-path" => search_catalog_path,
+              :available => document_available?,
+              :basemap => geoblacklight_basemap,
+              :leaflet_options => leaflet_options
+            })
+  end
 end

--- a/app/javascript/entrypoints/clover.js
+++ b/app/javascript/entrypoints/clover.js
@@ -1,0 +1,5 @@
+import { CloverInitializer } from '@geoblacklight/frontend'
+
+document.addEventListener('DOMContentLoaded', () => {
+  new CloverInitializer().run()
+})

--- a/app/javascript/entrypoints/ol.js
+++ b/app/javascript/entrypoints/ol.js
@@ -1,0 +1,6 @@
+import '@geoblacklight/frontend/dist/style.css'
+import { OlInitializer } from '@geoblacklight/frontend'
+
+document.addEventListener('DOMContentLoaded', () => {
+  new OlInitializer().run()
+})

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -8,22 +8,24 @@
 
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_tag '$.fx.off = true;' if Rails.env.test? %>
+    <%= vite_client_tag %>
+    <%= vite_javascript_tag 'application' %>
     <%= javascript_importmap_tags %>
     <!-- Google tag (gtag.js) -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-JWGGYRXL2K"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){ dataLayer.push(arguments); }
-    gtag('js', new Date());
-    
-    const config = {};
-    <% if Settings.analytics_debug %>
-      config.debug_mode = true
-    <% end %>
-        
-    gtag('config', 'G-JWGGYRXL2K', config)
-  </script>
-</head>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-JWGGYRXL2K"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){ dataLayer.push(arguments); }
+      gtag('js', new Date());
+
+      const config = {};
+      <% if Settings.analytics_debug %>
+        config.debug_mode = true
+      <% end %>
+
+      gtag('config', 'G-JWGGYRXL2K', config)
+    </script>
+  </head>
 
   <body>
     <%= yield %>

--- a/config/vite.json
+++ b/config/vite.json
@@ -1,0 +1,16 @@
+{
+  "all": {
+    "sourceCodeDir": "app/javascript",
+    "watchAdditionalPaths": []
+  },
+  "development": {
+    "autoBuild": true,
+    "publicOutputDir": "vite-dev",
+    "port": 3036
+  },
+  "test": {
+    "autoBuild": true,
+    "publicOutputDir": "vite-test",
+    "port": 3037
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "dependencies": {
+    "@geoblacklight/frontend": "^4.4"
+  },
+  "devDependencies": {
+    "vite": "^5.3.5",
+    "vite-plugin-rails": "^0.5.0",
+    "vite-plugin-ruby": "^5.0.0"
+  }
+}

--- a/vite.config.mts
+++ b/vite.config.mts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vite'
+import rails from 'vite-plugin-rails'
+
+export default defineConfig({
+  plugins: [
+    rails(),
+  ]
+})


### PR DESCRIPTION
Note: This is an exploratory branch for upgrading to GBL 4.4.0. I will likely go through this process again using what I've learned from the GeoBlacklight team. Currently just making this PR to confirm this runs on CI.

## Problem

Our GeoBlacklight is out of date (4.1.0)

## Solution

Upgrade to 4.4.0

## Type

chore