### PR TITLE
Disallow invalid URL that pattern Googlebot keeps trying to request

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -11,6 +11,7 @@ Disallow: /catalog.html?f
 Disallow: /catalog.html?_
 Disallow: /catalog.atom
 Disallow: /catalog.rss
+Disallow: /catalog/*/catalog/*
 Disallow: /catalog/*/relations
 Disallow: /catalog/facet/*
 Disallow: /catalog/*/web_services


### PR DESCRIPTION
## Problem

Googlebot keeps requesting URLs like `/catalog/F44DD53A-82DD-4B2B-B0AE-7B9352112DFD/catalog/nyu-2451-34565` which is not a valid request and returns a 404. In the last 24 hours alone there have been 15k requests for URLs like these.

## Solution

Add an entry to `robots.txt` to Disallow these URL requests from bots.

Addresses #316 

## Type

Chore