### PR TITLE
Update rexml gem to address DoS vulnerabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -420,7 +420,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     retriable (3.1.2)
-    rexml (3.3.2)
+    rexml (3.3.4)
       strscan
     rgeo (3.0.0)
     rgeo-geojson (2.1.1)


### PR DESCRIPTION
## Problem

There are 2 new DoS vulnerabilities in rexml 3.3.2

## Solution

Upgrade to 3.3.4

## Type

Dependencies