### PR TITLE
Switch to bundler-audit configuration file

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,0 +1,4 @@
+---
+ignore:
+  - CVE-2015-9284 # Temporarily ignore Omniauth vulnerability
+  - CVE-2024-6531 # No fix for this yet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,4 +29,4 @@ jobs:
         bundle exec rake db:schema:load
         bundle exec rake ci
     - name: Audit gems
-      run: bundle exec bundle-audit check --ignore CVE-2015-9284 # tempoarily ignore omniauth vulnerability
+      run: bundle exec bundle-audit check


### PR DESCRIPTION
## Problem

Ignored CVE's are managed separately between local development and GitHub Actions

## Solution

Use bundler audit's configuration file to ignore the same CVE's locally and in GitHub Action

This also adds CVE-2024-6531 which currently does not have a fix but is blocking builds from passing.

## Type

Chore