### PR TITLE
Add large directories to Rubocop's ignore list

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,9 @@ AllCops:
     - 'vendor/**/*'
     - 'Vagrantfile'
     - 'app/helpers/geoblacklight_helper.rb'
+    - 'coverage/**/*'
+    - 'log/**/*'
+    - 'tmp/**/*'
   NewCops: enable
 
 Style/Documentation:


### PR DESCRIPTION
## Problem

After running `sdr-cli clone` in my local development environment I ended up with a large number of directories under `tmp/opengeometadata`. This resulted in Rubocop taking a really long time to run, if it ever finished at all.

## Solution

Add `tmp` and other Git ignored directories to Rubocop's ignore list.

## Type

Chore