### PR TITLE
Remove unused feedback routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,9 +43,6 @@ Rails.application.routes.draw do
     get 'logout', to: 'devise/sessions#destroy', as: :logout
 
     resources :suggest, only: :index, defaults: {format: 'json'}
-
-    resource :feedback_form, path: 'feedback', only: [:new, :create]
-    get 'feedback' => 'feedback_forms#new'
   end
 end
 


### PR DESCRIPTION
## Problem

Our routes file has an extraneous `/feedback` routes that aren't used for anything.

## Solution

Remove them!

Addresses #359

## Type

Chore