### PR TITLE
Align routes.rb with default GBL routes setup

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,45 +1,51 @@
 Rails.application.routes.draw do
-  devise_for :users, path: '', controllers: {omniauth_callbacks: 'omniauth_callbacks'}
+  mount Blacklight::Engine => '/'
+  root to: "catalog#index"
+  concern :searchable, Blacklight::Routes::Searchable.new
+
+  resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
+    concerns :searchable
+  end
+  devise_for :users, path: '', controllers: { omniauth_callbacks: 'omniauth_callbacks' }
+
+  concern :exportable, Blacklight::Routes::Exportable.new
+
+  resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do
+    concerns :exportable
+  end
+
+  resources :bookmarks do
+    concerns :exportable
+
+    collection do
+      delete 'clear'
+    end
+  end
+  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
+
+  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
+  # Can be used by load balancers and uptime monitors to verify that the app is live.
+  get "up" => "rails/health#show", as: :rails_health_check
+
+  # Defines the root path route ("/")
+  # root "posts#index"
+  mount Geoblacklight::Engine => 'geoblacklight'
+  concern :gbl_exportable, Geoblacklight::Routes::Exportable.new
+  resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do
+    concerns :gbl_exportable
+  end
+  concern :gbl_wms, Geoblacklight::Routes::Wms.new
+  namespace :wms do
+    concerns :gbl_wms
+  end
+  concern :gbl_downloadable, Geoblacklight::Routes::Downloadable.new
+  namespace :download do
+    concerns :gbl_downloadable
+  end
+  resources :download, only: [:show]
+
+  # NYU Routes
   devise_scope :user do
-    mount Blacklight::Engine => '/'
-    mount Geoblacklight::Engine => 'geoblacklight'
-
-    root to: "catalog#index"
-    concern :searchable, Blacklight::Routes::Searchable.new
-
-    resource :catalog, only: [:index], as: 'catalog', path: '/catalog', controller: 'catalog' do
-      concerns :searchable
-    end
-
-    concern :exportable, Blacklight::Routes::Exportable.new
-
-    resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do
-      concerns :exportable
-    end
-
-    resources :bookmarks do
-      concerns :exportable
-
-      collection do
-        delete 'clear'
-      end
-    end
-
-    concern :gbl_exportable, Geoblacklight::Routes::Exportable.new
-    resources :solr_documents, only: [:show], path: '/catalog', controller: 'catalog' do
-      concerns :gbl_exportable
-    end
-    concern :gbl_wms, Geoblacklight::Routes::Wms.new
-    namespace :wms do
-      concerns :gbl_wms
-    end
-    concern :gbl_downloadable, Geoblacklight::Routes::Downloadable.new
-    namespace :download do
-      concerns :gbl_downloadable
-    end
-    resources :download, only: [:show]
-    
-    # NYU Routes
     get 'logout', to: 'devise/sessions#destroy', as: :logout
   end
 end


### PR DESCRIPTION
## Problem

While cleaning up the routes file in #360 #358 and #355 I noticed that our `routes.rb` was organized a little differently than a vanilla GBL app. I also noticed that we are unnecessarily wrapping all our routes in `devise_scope` when only the `logout` route needs it.

## Solution

Re-organize the routes file to follow a vanilla GBL routes files.

## Type

Chore