### PR TITLE
Strip out proxy from Rails-based WMS requests

### DIFF
--- a/app/controllers/wms_controller.rb
+++ b/app/controllers/wms_controller.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class WmsController < ApplicationController
+  def handle
+    # Overriding to use NYU Specific WMS Layer class
+    response = NyuGeoblacklight::WmsLayer.new(wms_params).feature_info
+
+    respond_to do |format|
+      format.json { render json: response }
+    end
+  end
+
+  private
+
+  def wms_params
+    params.permit(Settings.GBL_PARAMS)
+  end
+end

--- a/lib/nyugeoblacklight/wms_layer.rb
+++ b/lib/nyugeoblacklight/wms_layer.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+module NyuGeoblacklight
+  class WmsLayer < Geoblacklight::WmsLayer
+    def initialize(params)
+      # Overriding to strip proxy from WMS requests made by Rails app
+      params['URL'].gsub!('http://proxy.library.nyu.edu/login?url=', '')
+
+      super(params)
+    end
+  end
+end

--- a/spec/lib/nyu_geoblacklight/wms_layer_spec.rb
+++ b/spec/lib/nyu_geoblacklight/wms_layer_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe NyuGeoblacklight::WmsLayer do
+  context 'when the URL param contains the NYU proxy' do
+    it 'strips out the NYU proxy' do
+      wms_layer = described_class.new({ 'URL' => 'http://proxy.library.nyu.edu/login?url=http://example.com' })
+
+      expect(wms_layer.url).to eq('http://example.com')
+    end
+  end
+end


### PR DESCRIPTION
## Problem

Restricted records use the NYU proxy to let the front end load maps via the restricted GeoServer. When a user clicks on a feature to identify it, the request goes through the Rails server but the Rails app isn't allowed through the proxy.

## Solution

Strip the proxy from the WMS URL so that our backend requests go straight to the Restricted GeoServer.

Addresses #369 

## Type

bug-fix