### PR TITLE
Adds clarification when viewing restricted NYU records

### DIFF
--- a/app/models/concerns/rights_concern.rb
+++ b/app/models/concerns/rights_concern.rb
@@ -4,7 +4,7 @@ module RightsConcern
   extend Geoblacklight::SolrDocument
 
   def rights_text
-    "This dataset is only available to members of the <b>New York University</b> community and is limited to <em>current</em> students, staff, and faculty. Do not copy or redistribute this data. If you have questions about what constitutes fair use of this material, please contact us directly at <a href='mailto:data.services@nyu.edu'>data.services@nyu.edu</a>." if nyu? && restricted?
+    "This dataset is only available to members of the <b>New York University</b> community and is limited to <em>current</em> students, staff, and faculty. Do not copy or redistribute this data. If you have questions about what constitutes fair use of this material, please contact us directly at <a href='mailto:data.services@nyu.edu'>data.services@nyu.edu</a>.<br/><br/>Please note that access while on the NYU wifi network or via <a href='https://www.nyu.edu/life/information-technology/infrastructure/network-services/vpn.html'>NYU VPN</a> is required to preview the data below; authenticated users may use the asset download features without NYU VPN." if nyu? && restricted?
   end
 
   def nyu?


### PR DESCRIPTION
## Problem

It may be unclear to folks not on the NYU VPN/Network as to why they can't preview NYU restricted records

## Solution

Add additional explanation to the alert for restricted records explaining why you might not be able to see the data.

## Type

Enhancement

## Screenshots

### Before

<img width="846" alt="Screenshot 2024-09-13 at 11 00 29 AM" src="https://github.com/user-attachments/assets/1fae8ab7-4457-4fbe-b2ff-3d51b748618f">

### After

<img width="842" alt="Screenshot 2024-09-13 at 11 00 35 AM" src="https://github.com/user-attachments/assets/e0ae067a-ee8c-4f1a-b243-5a49fe58c2e8">
