### PR TITLE
Remove expired links in Dublin LiDAR record alert

### DIFF
--- a/app/views/catalog/_laefer_notice.html.erb
+++ b/app/views/catalog/_laefer_notice.html.erb
@@ -2,8 +2,7 @@
 <div class="alert alert-warning alert-dismissible" role="alert">
   <button type="button" class="close" data-dismiss="alert" aria-label="Close"><span aria-hidden="true">&times;</span>
   </button>
-  Thank you for your interest in data from the <%= link_to search_catalog_path({f: {"#{Settings.FIELDS.PART_OF}" => ['2015 Dublin LiDAR']}}) do %><b>2015 Dublin LiDAR</b><% end %> project.<br><br>
-  We would appreciate your feedback on this unique dataset. Please take a moment to fill out <a href="https://nyu.qualtrics.com/jfe/form/SV_42ddIXjT0CtaqAR" target="_blank">this brief survey</a> telling us a little bit about yourself, how you found the data, and how you are using it.
-  Having an accurate idea of how users are accessing and using the data is essential to being able to produce datasets of this magnitude.<br><br>
-  For a better sense of what this data looks like in 3D, please refer to <a href="https://youtu.be/qEi2Wo7Bcuk">this video flythrough</a> of a portion of the covered area.<br><br>Please cite this study using the DOI: <code><a href="https://doi.org/10.17609/N8MQ0N">doi:10.17609/N8MQ0N</a></code>
+  Thank you for your interest in data from the 2015 Dublin LiDAR project.<br><br>
+  For a better sense of what this data looks like in 3D, please refer to <a href="https://youtu.be/qEi2Wo7Bcuk">this video flythrough</a> of a portion of the covered area.<br><br>
+  Please cite this study using the DOI: <code><a href="https://doi.org/10.17609/N8MQ0N">doi:10.17609/N8MQ0N</a></code>
 </div>

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -46,13 +46,6 @@ describe 'Show page' do
       expect(page).to have_selector 'div.alert.alert-warning'
     end
 
-    it 'includes survey link' do
-      visit solr_document_path 'nyu-2451-38684'
-      expect(page).to have_link(
-        'this brief survey', href: 'https://nyu.qualtrics.com/jfe/form/SV_42ddIXjT0CtaqAR'
-      )
-    end
-
     it 'does not display download' do
       visit solr_document_path 'nyu-2451-38684'
       expect(page).not_to have_content 'Download'
@@ -60,7 +53,9 @@ describe 'Show page' do
 
     it 'includes DOI for citation' do
       visit solr_document_path 'nyu-2451-38684'
-      expect(page).to have_content 'Please cite this study using the DOI'
+      expect(page).to have_link(
+        'doi:10.17609/N8MQ0N', href: 'https://doi.org/10.17609/N8MQ0N'
+      )
     end
   end
 


### PR DESCRIPTION
## Problem
Alert message on Dublin LiDAR records have expired links and surveys that are no longer active

## Solution
Remove expired links and maintain the reference to the YouTube flyover video and the DOI.

## Type
chore
