### PR TITLE
bump sdr_cli version, pin to tag

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,7 +28,7 @@ gem 'rails', '~> 7.0.6'
 gem 'rsolr', '>= 1.0', '< 3'
 gem 'sassc-rails', '~> 2.1'
 gem 'sdoc', group: :doc
-gem 'sdr_cli', github: 'NYULibraries/sdr-cli'
+gem 'sdr_cli', github: 'NYULibraries/sdr-cli', tag: 'v0.2.0'
 gem 'sprockets', '< 4.0'
 gem 'sprockets-rails'
 gem 'stimulus-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 GIT
   remote: https://github.com/NYULibraries/sdr-cli.git
-  revision: 81663a55da61ffd1df60c212287636154b20b285
+  revision: 9807e7ac14ac060d6d27456103745834406c3527
+  tag: v0.2.0
   specs:
-    sdr_cli (0.1.0)
+    sdr_cli (0.2.0)
       dotenv (~> 2.7)
       faraday (~> 2.10.1)
       thor (~> 1.2.2)


### PR DESCRIPTION
Tiny PR to bump `sdr_cli` version number in Gemfile & Gemfile.lock.

In short, the new `sdr_cli` version updates the `index` command's `--directory` option to more intuitively take a path to a local directory rather than a Glob string matching record paths.