### PR TITLE
Update REXML for CVE-2024-49761

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -403,8 +403,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     retriable (3.1.2)
-    rexml (3.3.6)
-      strscan
+    rexml (3.3.9)
     rgeo (3.0.1)
     rgeo-geojson (2.2.0)
       multi_json (~> 1.15)
@@ -508,7 +507,6 @@ GEM
     stimulus-rails (1.2.2)
       railties (>= 6.0.0)
     stringio (3.1.1)
-    strscan (3.1.0)
     thor (1.2.2)
     thread_safe (0.3.6)
     tilt (2.4.0)


### PR DESCRIPTION
## Problem

There's a vulnerability in the version of REXML we're using.

## Solution

Update to a fixed version

## Type

Dependencies