### PR TITLE
workaround for core exists error

### DIFF
--- a/lib/tasks/sdr.rake
+++ b/lib/tasks/sdr.rake
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+
 desc 'Run test suite'
 task ci: :environment do
   shared_solr_opts = { managed: true, verbose: true, persist: false, download_dir: 'tmp' }
@@ -17,10 +19,10 @@ end
 namespace :sdr do
   desc 'Run Solr and GeoBlacklight for interactive development'
   task server: %i[environment] do |_t, _args|
-    require 'solr_wrapper'
-
     shared_solr_opts = { managed: true, verbose: true, persist: false, download_dir: 'tmp' }
     shared_solr_opts[:version] = Settings.SOLR_VERSION if Settings.SOLR_VERSION
+
+    FileUtils.rm_rf Settings.SOLR_INSTANCE_DIR
 
     SolrWrapper.wrap(shared_solr_opts.merge(port: Settings.SOLR_PORT, instance_dir: Settings.SOLR_INSTANCE_DIR)) do |solr|
       solr.with_collection(name: Settings.SOLR_INSTANCE_NAME, dir: Rails.root.join('solr/conf').to_s) do


### PR DESCRIPTION
Small fix for a very old solr_wrapper issue. See: https://github.com/cbeer/solr_wrapper/issues/69 and https://github.com/NYULibraries/spatial_data_repository/issues/47. Tagged as `chore` bc it only impacts local dev/test instance
