### PR TITLE
Update net-imap, nokogiri and rack due to CVEs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -310,7 +310,7 @@ GEM
       uri
     net-http-persistent (4.0.2)
       connection_pool (~> 2.2)
-    net-imap (0.5.4)
+    net-imap (0.5.6)
       date
       net-protocol
     net-pop (0.1.2)
@@ -324,9 +324,9 @@ GEM
     net-ssh (7.2.0)
     newrelic_rpm (9.11.0)
     nio4r (2.7.4)
-    nokogiri (1.18.0-arm64-darwin)
+    nokogiri (1.18.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.0-x86_64-linux-gnu)
+    nokogiri (1.18.3-x86_64-linux-gnu)
       racc (~> 1.4)
     oauth2 (2.0.9)
       faraday (>= 0.17.3, < 3.0)
@@ -358,7 +358,7 @@ GEM
     puma (5.6.9)
       nio4r (~> 2.0)
     racc (1.8.1)
-    rack (2.2.10)
+    rack (2.2.11)
     rack-attack (6.7.0)
       rack (>= 1.0, < 4)
     rack-proxy (0.7.7)


### PR DESCRIPTION
## Problem

There are a few CVEs that break the build.

## Solution

Update the affected gems: net-map, nokogiri and rack

## Type

Dependencies