### PR TITLE
Updated Node version required by Vite and remove deprecated JS frontend libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v4
     - uses: actions/setup-node@v4
       with:
-        node-version: 22.7.0
+        node-version: 22.12.0
     - name: Install NodeJS Dependencies
       run: npm ci
     - name: Set up Ruby

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,3 +1,3 @@
 ruby 3.2.2
 java openjdk-17
-nodejs 22.7.0
+nodejs 22.12.0

--- a/app/javascript/entrypoints/clover.js
+++ b/app/javascript/entrypoints/clover.js
@@ -1,5 +1,0 @@
-import { CloverInitializer } from '@geoblacklight/frontend'
-
-document.addEventListener('DOMContentLoaded', () => {
-  new CloverInitializer().run()
-})

--- a/app/javascript/entrypoints/ol.js
+++ b/app/javascript/entrypoints/ol.js
@@ -1,6 +1,0 @@
-import '@geoblacklight/frontend/dist/style.css'
-import { OlInitializer } from '@geoblacklight/frontend'
-
-document.addEventListener('DOMContentLoaded', () => {
-  new OlInitializer().run()
-})

--- a/app/views/layouts/blacklight/base.html.erb
+++ b/app/views/layouts/blacklight/base.html.erb
@@ -19,11 +19,6 @@
     <%= javascript_include_tag "application", "data-turbo-track": "reload" %>
 
     <%= vite_client_tag %>
-    <% if openlayers_container? %>
-      <%= vite_javascript_tag 'ol' %>
-    <% elsif iiif_manifest_container? %>
-      <%= vite_javascript_tag 'clover' %>
-    <% end %>
 
     <%= csrf_meta_tags %>
     <%= content_for(:head) %>

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -13,12 +13,12 @@ set :branch, :main
 # Use rbenv for Ruby version management
 set :rbenv_type, :user
 set :rbenv_ruby, File.read('.ruby-version').strip
-set :node_version, '22.7.0'
+set :node_version, '22.12.0'
 
 # Pass additional environment variables to the server
 set :default_env, {
   RAILS_ENV: 'production',
-  PATH: "/home/ubuntu/.nvm/versions/node/v22.7.0/bin:/home/ubuntu/.rbenv/plugins/ruby-build/bin:/home/ubuntu/.rbenv/shims:/home/ubuntu/.rbenv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
+  PATH: "/home/ubuntu/.nvm/versions/node/v22.12.0/bin:/home/ubuntu/.rbenv/plugins/ruby-build/bin:/home/ubuntu/.rbenv/shims:/home/ubuntu/.rbenv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/usr/games:/usr/local/games:/snap/bin"
 }
 
 # Number of versions to keep (for rollback)

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,7 +4,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "spatial_data_repository",
       "dependencies": {
         "@geoblacklight/frontend": "^5.2.0"
       },
@@ -226,9 +225,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -246,9 +242,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -266,9 +259,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -286,9 +276,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -306,9 +293,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -326,9 +310,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -513,9 +494,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -531,9 +509,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -549,9 +524,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -567,9 +539,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -585,9 +554,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -603,9 +569,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -621,9 +584,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -639,9 +599,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -657,9 +614,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -675,9 +629,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -693,9 +644,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -711,9 +659,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -729,9 +674,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1151,9 +1093,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1175,9 +1114,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1199,9 +1135,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -1223,9 +1156,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [


### PR DESCRIPTION
## Problem

While doing a deployment with the latest updates we discovered:

- Vite requires Node 22.12.0+
- OpenLayers and Clover are not included in Geoblacklight's frontend code anymore (and we don't use these)

## Solution

- Update Node version to 22.12.0
- Remove OL and Clover references

## Type

bug-fix