### PR TITLE
Updates gems and addresses Devise CVE-2026-40295

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,8 +17,8 @@ jobs:
     runs-on: ubuntu-latest
     name: test
     steps:
-    - uses: actions/checkout@v4
-    - uses: actions/setup-node@v4
+    - uses: actions/checkout@v6
+    - uses: actions/setup-node@v6
       with:
         node-version: 22.12.0
     - name: Install NodeJS Dependencies
@@ -30,7 +30,7 @@ jobs:
     - name: Lint
       run: bundle exec rubocop
     - name: Cache Solr Download
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: |
           ./tmp/solr-9.2.1.tgz

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,14 +91,16 @@ GEM
     archive-zip (0.13.1)
       io-like (~> 0.4.0)
     ast (2.4.3)
+    auth-sanitizer (0.1.2)
+      version_gem (~> 1.1, >= 1.1.9)
     autoprefixer-rails (10.4.21.0)
       execjs (~> 2)
-    axe-core-api (4.11.2)
+    axe-core-api (4.11.3)
       dumb_delegator
       ostruct
       virtus
-    axe-core-rspec (4.11.2)
-      axe-core-api (= 4.11.2)
+    axe-core-rspec (4.11.3)
+      axe-core-api (= 4.11.3)
       dumb_delegator
       ostruct
       virtus
@@ -123,7 +125,7 @@ GEM
       rails (>= 6.1, < 8.1)
       view_component (>= 2.74, < 4)
       zeitwerk
-    bootsnap (1.24.1)
+    bootsnap (1.24.4)
       msgpack (~> 1.2)
     bootstrap (4.6.2.1)
       autoprefixer-rails (>= 9.1.0)
@@ -134,7 +136,7 @@ GEM
       thor (~> 1.0)
     byebug (13.0.0)
       reline (>= 0.6.0)
-    capistrano (3.20.0)
+    capistrano (3.20.1)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -188,7 +190,7 @@ GEM
       activesupport
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
-    devise (5.0.3)
+    devise (5.0.4)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 7.0)
@@ -204,18 +206,18 @@ GEM
     erb (6.0.4)
     erubi (1.13.1)
     execjs (2.10.1)
-    factory_bot (6.5.6)
+    factory_bot (6.6.0)
       activesupport (>= 6.1.0)
     factory_bot_rails (6.5.1)
       factory_bot (~> 6.5)
       railties (>= 6.1.0)
-    faraday (2.14.1)
+    faraday (2.14.2)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-follow_redirects (0.5.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.3)
       net-http (~> 0.5)
     faraday-net_http_persistent (2.3.1)
       faraday (~> 2.5)
@@ -277,18 +279,18 @@ GEM
       prism (>= 1.3.0)
       rdoc (>= 4.0.0)
       reline (>= 0.4.2)
-    jbuilder (2.14.1)
+    jbuilder (2.15.0)
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     jquery-rails (4.6.1)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    json (2.19.4)
+    json (2.19.5)
     json-schema (6.2.0)
       addressable (~> 2.8)
       bigdecimal (>= 3.1, < 5)
-    jwt (3.1.2)
+    jwt (3.2.0)
       base64
     kaminari (1.2.2)
       activesupport (>= 4.1.0)
@@ -318,7 +320,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.1.0)
+    marcel (1.2.1)
     matrix (0.4.3)
     method_source (1.1.0)
     mime-types (3.7.0)
@@ -329,8 +331,8 @@ GEM
     minitar (1.1.0)
     minitest (5.27.0)
     msgpack (1.8.0)
-    multi_json (1.20.1)
-    multi_xml (0.8.1)
+    multi_json (1.21.1)
+    multi_xml (0.9.1)
       bigdecimal (>= 3.1, < 5)
     mutex_m (0.3.0)
     mysql2 (0.5.7)
@@ -353,14 +355,15 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     net-ssh (7.3.2)
-    newrelic_rpm (10.4.0)
+    newrelic_rpm (10.5.0)
       logger
     nio4r (2.7.5)
     nokogiri (1.19.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
-    oauth2 (2.0.18)
+    oauth2 (2.0.19)
+      auth-sanitizer (~> 0.1)
       faraday (>= 0.17.3, < 4.0)
       jwt (>= 1.0, < 4.0)
       logger (~> 1.2)
@@ -377,7 +380,7 @@ GEM
     omniauth-rails_csrf_protection (0.1.2)
       actionpack (>= 4.2)
       omniauth (>= 1.3.1)
-    openssl (3.3.2)
+    openssl (3.3.3)
     orm_adapter (0.5.0)
     ostruct (0.6.3)
     parallel (1.28.0)
@@ -401,7 +404,7 @@ GEM
     rack (2.2.23)
     rack-attack (6.8.0)
       rack (>= 1.0, < 4)
-    rack-proxy (0.7.7)
+    rack-proxy (0.8.2)
       rack
     rack-session (1.0.2)
       rack (< 3)
@@ -480,7 +483,7 @@ GEM
       rspec-mocks (>= 3.13.0, < 5.0.0)
       rspec-support (>= 3.13.0, < 5.0.0)
     rspec-support (3.13.7)
-    rubocop (1.86.1)
+    rubocop (1.86.2)
       json (~> 2.3)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.1.0)
@@ -494,9 +497,9 @@ GEM
     rubocop-ast (1.49.1)
       parser (>= 3.3.7.2)
       prism (~> 1.7)
-    rubocop-capybara (2.22.1)
+    rubocop-capybara (2.23.0)
       lint_roller (~> 1.1)
-      rubocop (~> 1.72, >= 1.72.1)
+      rubocop (~> 1.81)
     rubocop-factory_bot (2.28.0)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
@@ -504,7 +507,7 @@ GEM
       lint_roller (~> 1.1)
       rubocop (>= 1.75.0, < 2.0)
       rubocop-ast (>= 1.47.1, < 2.0)
-    rubocop-rails (2.34.3)
+    rubocop-rails (2.35.2)
       activesupport (>= 4.2.0)
       lint_roller (~> 1.1)
       rack (>= 1.1)
@@ -518,7 +521,7 @@ GEM
       rubocop (~> 1.72, >= 1.72.1)
       rubocop-rspec (~> 3.5)
     ruby-progressbar (1.13.0)
-    rubyzip (3.2.2)
+    rubyzip (3.3.0)
     sanitize (7.0.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.16.8)
@@ -533,7 +536,7 @@ GEM
     sdoc (2.6.5)
       rdoc (>= 5.0)
     securerandom (0.4.1)
-    selenium-webdriver (4.43.0)
+    selenium-webdriver (4.44.0)
       base64 (~> 0.2)
       logger (~> 1.4)
       rexml (~> 3.2, >= 3.2.5)
@@ -545,7 +548,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.13.2)
     simplecov_json_formatter (0.1.4)
-    snaky_hash (2.0.3)
+    snaky_hash (2.0.4)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
     solr_wrapper (4.4.0)
@@ -555,7 +558,7 @@ GEM
       ostruct
       retriable
       ruby-progressbar
-    spring (4.4.2)
+    spring (4.5.0)
     sprockets (3.7.5)
       base64
       concurrent-ruby (~> 1.0)
@@ -564,8 +567,8 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    sqlite3 (2.9.3-arm64-darwin)
-    sqlite3 (2.9.3-x86_64-linux-gnu)
+    sqlite3 (2.9.4-arm64-darwin)
+    sqlite3 (2.9.4-x86_64-linux-gnu)
     sshkit (1.25.0)
       base64
       logger
@@ -606,7 +609,7 @@ GEM
       axiom-types (~> 0.1)
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
-    vite_rails (3.10.0)
+    vite_rails (3.11.0)
       railties (>= 5.1, < 9)
       vite_ruby (~> 3.0, >= 3.2.2)
     vite_ruby (3.10.2)
@@ -629,7 +632,7 @@ GEM
       whenever
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    zeitwerk (2.7.5)
+    zeitwerk (2.8.1)
 
 PLATFORMS
   arm64-darwin-22

--- a/spec/components/curated_maps/curated_map_component_spec.rb
+++ b/spec/components/curated_maps/curated_map_component_spec.rb
@@ -14,6 +14,6 @@ RSpec.describe CuratedMaps::CuratedMapComponent, type: :component do
   it 'renders the map title' do
     render_inline(described_class.new(map:))
 
-    expect(page).to have_content(map[:title])
+    expect(page).to have_text(map[:title])
   end
 end

--- a/spec/components/curated_maps/curated_maps_component_spec.rb
+++ b/spec/components/curated_maps/curated_maps_component_spec.rb
@@ -14,6 +14,6 @@ RSpec.describe CuratedMaps::CuratedMapsComponent, type: :component do
   it 'renders the maps title' do
     render_inline(described_class.new(maps:))
 
-    expect(page).to have_content('Featured Maps')
+    expect(page).to have_text('Featured Maps')
   end
 end

--- a/spec/features/homepage_spec.rb
+++ b/spec/features/homepage_spec.rb
@@ -4,12 +4,12 @@ describe 'Homepage' do
   describe 'DOM' do
     it 'has Featured Collections' do
       visit root_path
-      expect(page).to have_content 'Featured Collections'
+      expect(page).to have_text 'Featured Collections'
     end
 
     it 'has Featured Maps' do
       visit root_path
-      expect(page).to have_content 'Featured Maps'
+      expect(page).to have_text 'Featured Maps'
     end
   end
 

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -6,7 +6,7 @@ describe 'Search' do
       visit root_path
       fill_in 'q', with: 'prince'
       click_button 'search'
-      expect(page).to have_content 'Did you mean to type:'
+      expect(page).to have_text 'Did you mean to type:'
     end
   end
 end

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -5,12 +5,12 @@ describe 'Show page' do
     context 'when signed out' do
       it 'displays warning message' do
         visit solr_document_path 'nyu-2451-34626'
-        expect(page).to have_content 'This dataset is only available to members of the New York University community'
+        expect(page).to have_text 'This dataset is only available to members of the New York University community'
       end
 
       it 'displays the download message' do
         visit solr_document_path 'nyu-2451-34626'
-        expect(page).to have_content 'In order to download the data'
+        expect(page).to have_text 'In order to download the data'
       end
 
       it 'does not display download' do
@@ -68,15 +68,15 @@ describe 'Show page' do
   context 'with multiple downloads - nyu-2451-38645' do
     it 'includes six download links' do
       visit solr_document_path 'nyu-2451-38645'
-      expect(page).to have_content 'Download'
+      expect(page).to have_text 'Download'
       click_on 'Download'
 
-      expect(page).to have_content('LAZ (Point-cloud)')
-      expect(page).to have_content('LAS (Full-waveform)')
-      expect(page).to have_content('Pulsewaves (Full-waveform)')
-      expect(page).to have_content('GeoTIFF (Geo-referenced RGB)')
-      expect(page).to have_content('GeoTIFF (Geo-referenced CIR)')
-      expect(page).to have_content('JPG (Oblique photos)')
+      expect(page).to have_text('LAZ (Point-cloud)')
+      expect(page).to have_text('LAS (Full-waveform)')
+      expect(page).to have_text('Pulsewaves (Full-waveform)')
+      expect(page).to have_text('GeoTIFF (Geo-referenced RGB)')
+      expect(page).to have_text('GeoTIFF (Geo-referenced CIR)')
+      expect(page).to have_text('JPG (Oblique photos)')
     end
   end
   # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations

--- a/spec/features/show_page_spec.rb
+++ b/spec/features/show_page_spec.rb
@@ -16,7 +16,7 @@ describe 'Show page' do
       it 'does not display download' do
         visit solr_document_path 'nyu-2451-34626'
         # rubocop:disable Capybara/NegationMatcherAfterVisit
-        expect(page).to have_no_content 'Export'
+        expect(page).to have_no_text 'Export'
         # rubocop:enable Capybara/NegationMatcherAfterVisit
       end
     end
@@ -51,7 +51,7 @@ describe 'Show page' do
     it 'does not display download' do
       visit solr_document_path 'nyu-2451-38684'
       # rubocop:disable Capybara/NegationMatcherAfterVisit
-      expect(page).to have_no_content 'Download'
+      expect(page).to have_no_text 'Download'
       # rubocop:enable Capybara/NegationMatcherAfterVisit
     end
 


### PR DESCRIPTION
## Problem

There is a Devise CVE that will prevent CI from passing

## Solution

Update gems!

This also updates GitHub Actions to remove their warnings.

## Type

dependencies