### PR TITLE
Tighten Rack::Attack throttling to reduce crawler load

### DIFF
--- a/config/initializers/rack_attack.rb
+++ b/config/initializers/rack_attack.rb
@@ -1,8 +1,15 @@
 class Rack::Attack
-  # Throttle all requests by IP (60rpm)
-  #
-  # Key: "rack::attack:#{Time.now.to_i/:period}:req/ip:#{req.ip}"
-  throttle('req/ip', limit: 300, period: 5.minutes) do |req|
+  # Tighten to 60 requests per 5 minutes
+  throttle('req/ip', limit: 60, period: 5.minutes) do |req|
     req.ip unless req.path.start_with?('/assets')
+  end
+
+  # Stricter for search requests
+  throttle('search/ip', limit: 20, period: 1.minute) do |req|
+    req.ip if req.path == '/' && req.query_string.include?('f%5B')
+  end
+
+  self.throttled_responder = lambda do |request|
+    [429, {'Content-Type' => 'text/plain'}, ["Rate limit exceeded\n"]]
   end
 end


### PR DESCRIPTION
Tighten Rack::Attack throttling to reduce crawler load

## Problem
Server experiencing 95% CPU usage due to excessive crawler and bot traffic
overwhelming Passenger Ruby workers. Default throttle limit of 300 requests
per 5 minutes was too permissive to provide meaningful protection.
Faceted search requests were particularly expensive as each triggers
a full Solr query and view render.

## Solution
- Reduce general request limit from 300 to 60 per 5 minutes
- Add dedicated faceted search throttle of 20 requests per minute to
  accommodate legitimate users while limiting crawler impact
- Return 429 Too Many Requests instead of default response

## Type
chore
